### PR TITLE
Allow a dot in the default format

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -243,7 +243,7 @@ return {
                             is_level = true
                         end
                     end
-                elseif arg:match("^%w[%w\\.]*$") then
+                elseif arg:match("^[%w%.]+$") then
                     -- Handle default extension (e.g., 7z, zip)
                     if archive_commands["%." .. arg .. "$"] then
                         default_extension = arg
@@ -494,3 +494,4 @@ return {
         end
     end
 }
+


### PR DESCRIPTION
This allows the default format to be "tar.gz", etc (as is mentionned in the README)

Before, as the default format was only looked for without a ".", formats such as tar.gz couldn't be used as default.

For example:
```toml
[[mgr.prepend_keymap]]
on = ["A", "z"]
run = "plugin compress 'tar.gz'"
desc = "Tar"
```
-> Expected behavior: I can enter a filename, and it will automatically be used as the base of a `.tar.gz` archive
-> Buggy behavior: it would just create a `.zip` file, as my argument was never parsed