### PR TITLE
fix(deprecated): use fs.unique instead of fs.unique_name

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -453,7 +453,7 @@ return {
 		-- Create a temporary directory for intermediate files
 		local temp_dir_name = ".tmp_compress"
 		local temp_dir = combine_url(output_dir, temp_dir_name)
-		temp_dir = tostring(fs.unique_name(Url(temp_dir)))
+		temp_dir = tostring(fs.unique("dir", Url(temp_dir)))
 
 		-- Attempt to create the temporary directory
 		local temp_dir_status, temp_dir_err = fs.create("dir_all", Url(temp_dir))
@@ -525,7 +525,7 @@ return {
 		-- Move the final file from the temporary directory to the output directory
 		local final_output_url = combine_url(output_dir, original_name)
 		local temp_url_processed = combine_url(temp_dir, original_name)
-		final_output_url = tostring(fs.unique_name(Url(final_output_url)))
+		final_output_url = tostring(fs.unique("file", Url(final_output_url)))
 		local from, to = Url(temp_url_processed), Url(final_output_url)
 		local move_status, move_err = fs.rename(from, to)
 		if not move_status then


### PR DESCRIPTION
Yazi thows a warning on recent versions because `fs.unique_name` is deprecated in favor of `fs.unique` (see github.com/sxyazi/yazi/pull/3677).