### PR TITLE
feat: add -s flag to silence success message

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ desc = "Archive selected files (password+header+level)"
 - `-p` Password protect (zip/7z/rar)
 - `-h` Encrypt header (7z/rar)
 - `-l` Set compression level (all compression algorithims)
+- `-s` Silence success message
 - `<extention>` Specify a default extention (eg., `7z`, `tar.gz`)
 
 #### Combining multiple flags:

--- a/main.lua
+++ b/main.lua
@@ -5,6 +5,7 @@ local is_windows = ya.target_family() == "windows"
 
 -- Define default flags and strings
 local is_password, is_encrypted, is_level = false, false, false
+local silent = false
 local default_extension = "zip"
 
 -- Function to check valid filename
@@ -342,6 +343,8 @@ return {
 							is_encrypted = true
 						elseif flag == "l" then
 							is_level = true
+						elseif flag == "s" then
+							silent = true
 						end
 					end
 				elseif arg:match("^[%w%.]+$") then
@@ -563,6 +566,8 @@ return {
 		cleanup_temp_dir(temp_dir)
 
 		-- Notify user of success
-		notify(string.format("Successfully created archive: %s", ya.quote(to.name)), "info")
+		if not silent then
+			notify(string.format("Successfully created archive: %s", ya.quote(to.name)), "info")
+		end
 	end,
 }

--- a/main.lua
+++ b/main.lua
@@ -4,8 +4,7 @@
 local is_windows = ya.target_family() == "windows"
 
 -- Define default flags and strings
-local is_password, is_encrypted, is_level = false, false, false
-local silent = false
+local is_password, is_encrypted, is_level, is_silent_success = false, false, false, false
 local default_extension = "zip"
 
 -- Function to check valid filename
@@ -344,7 +343,7 @@ return {
 						elseif flag == "l" then
 							is_level = true
 						elseif flag == "s" then
-							silent = true
+							is_silent_success = true
 						end
 					end
 				elseif arg:match("^[%w%.]+$") then
@@ -566,7 +565,7 @@ return {
 		cleanup_temp_dir(temp_dir)
 
 		-- Notify user of success
-		if not silent then
+		if not is_silent_success then
 			notify(string.format("Successfully created archive: %s", ya.quote(to.name)), "info")
 		end
 	end,


### PR DESCRIPTION
Adds a new flag `-s` that can be used to silence the success message (but warnings and errors are kept).