### PR TITLE
fix: handle dotted default extension arguments like tar.gz

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -7,6 +7,7 @@ local is_windows = ya.target_family() == "windows"
 local is_password, is_encrypted, is_level = false, false, false
 local default_extension = "zip"
 
+-- Allow dots when matching file extension arguments
 local function extension_pattern(ext)
 	return "%." .. ext:gsub("%.", "%%.") .. "$"
 end

--- a/main.lua
+++ b/main.lua
@@ -7,6 +7,10 @@ local is_windows = ya.target_family() == "windows"
 local is_password, is_encrypted, is_level = false, false, false
 local default_extension = "zip"
 
+local function extension_pattern(ext)
+	return "%." .. ext:gsub("%.", "%%.") .. "$"
+end
+
 -- Function to check valid filename
 local function is_valid_filename(name)
 	-- Trim whitespace from both ends
@@ -346,7 +350,7 @@ return {
 					end
 				elseif arg:match("^[%w%.]+$") then
 					-- Handle default extension (e.g., 7z, zip)
-					if archive_commands["%." .. arg .. "$"] then
+					if archive_commands[extension_pattern(arg)] then
 						default_extension = arg
 					else
 						notify(string.format("Unsupported extension: %s", arg), "warn")


### PR DESCRIPTION
Thanks for maintaining this plugin — I've really been enjoying it.

I was trying to use it from Yazi with a custom opener that calls `plugin compress tar.gz`, so folders could be archived directly to `tar.gz` from the interactive open menu. In that flow I consistently hit `Unsupported extension: tar.gz`, even though `tar.gz` is documented as a supported default extension.

This patch escapes dots when building the lookup key for default extensions, so dotted formats like `tar.gz` resolve correctly.

If this approach looks reasonable, I'd be happy to adjust it.